### PR TITLE
[WIP] CSRF protection

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "cat-log": "^1.0.2",
+    "csrf": "^3.0.3",
     "got": "^6.3.0",
     "lodash": "^4.15.0",
     "node-exceptions": "^1.0.3",

--- a/src/Exceptions/index.js
+++ b/src/Exceptions/index.js
@@ -132,4 +132,30 @@ class RuntimeException extends NE.RuntimeException {
 
 }
 
-module.exports = { InvalidArgumentException, OAuthException, RuntimeException }
+class CsrfException extends NE.DomainException {
+
+  /**
+   * Default error code to be used when user does not
+   * specify error code for an error.
+   *
+   * @return {Number}
+   */
+  static get defaultErrorCode () {
+    return 403
+  }
+
+  /**
+   * This exception is raised when the csrf token is invalid
+   *
+   * @param  {String} driver
+   * @param  {Number} [code=500]
+   *
+   * @return {Object}
+   */
+  static badToken () {
+    return new this('Bad CSRF token', this.defaultErrorCode, 'E_BAD_CSRF_TOKEN')
+  }
+
+}
+
+module.exports = { InvalidArgumentException, OAuthException, RuntimeException, CsrfException }


### PR DESCRIPTION
This is just a rough solution to https://github.com/adonisjs/adonis-ally/issues/2. What do you think about this approach?

Another approach could be to just expose some sort of CSRF secret/token for each driver to handle verifying.

Ultimately, this kind of check could be done at the controller level. I think it would be nice to have it enforced (or at least suggested) by the framework since CSRF protection is required by the spec.