### PR TITLE
feat(auth-provider): Add Discord auth with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ BOOM! Now you are good to make use of the ally provider and authenticate your us
 ## <a name="available-drivers"></a>Available Drivers
 Below is the list of available drivers and you are free to add more.
 
-1. Facebook
-2. Github
-3. Google
-4. LinkedIn
-5. Twitter
+1. Discord
+2. Facebook
+3. Github
+4. Google
+5. LinkedIn
+6. Twitter
 
 <br>
 ## <a name="config"></a>Config

--- a/examples/config.js
+++ b/examples/config.js
@@ -60,6 +60,21 @@ module.exports = {
       clientId: Env.get('GITHUB_CLIENT_ID'),
       clientSecret: Env.get('GITHUB_CLIENT_SECRET'),
       redirectUri: `${Env.get('APP_URL')}/authenticated/github`
+    },
+
+    /*
+    |--------------------------------------------------------------------------
+    | Discord Configuration
+    |--------------------------------------------------------------------------
+    |
+    | You can access your application credentials from the discord developers
+    | console. https://discordapp.com/developers/applications/me
+    |
+    */
+    discord: {
+      clientId: Env.get('DISCORD_CLIENT_ID'),
+      clientSecret: Env.get('DISCORD_CLIENT_SECRET'),
+      redirectUri: `${Env.get('APP_URL')}/authenticated/discord`
     }
   }
 }

--- a/examples/discord.js
+++ b/examples/discord.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const Ioc = require('adonis-fold').Ioc
+const config = require('./setup/config')
+const http = require('./setup/http')
+const AllyManager = require('../src/AllyManager')
+Ioc.bind('Adonis/Src/Config', () => {
+  return config
+})
+
+http.get('/discord', function * (request, response) {
+  const ally = new AllyManager(request, response)
+  const discord = ally.driver('discord')
+  response.writeHead(200, {'content-type': 'text/html'})
+  const url = yield discord.getRedirectUrl()
+  response.write(`<a href="${url}">Login With Discord</a>`)
+  response.end()
+})
+
+http.get('/discord/authenticated', function * (request, response) {
+  const ally = new AllyManager(request, response)
+  const discord = ally.driver('discord')
+  try {
+    const user = yield discord.getUser()
+    response.writeHead(200, {'content-type': 'application/json'})
+    response.write(JSON.stringify({ original: user.getOriginal(), profile: user.toJSON() }))
+  } catch (e) {
+    response.writeHead(500, {'content-type': 'application/json'})
+    response.write(JSON.stringify({ error: e }))
+  }
+  response.end()
+})
+
+http.start().listen(8000)

--- a/src/Drivers/Discord.js
+++ b/src/Drivers/Discord.js
@@ -1,0 +1,193 @@
+'use strict'
+
+/*
+ * adonis-ally
+ *
+ * (c) Aeryax <contrib@kazhord.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+const CE = require('../Exceptions')
+const OAuth2Scheme = require('../Schemes/OAuth2')
+const AllyUser = require('../AllyUser')
+const got = require('got')
+const utils = require('../../lib/utils')
+const _ = utils.mixLodash(require('lodash'))
+
+class Discord extends OAuth2Scheme {
+
+  constructor (Config) {
+    const config = Config.get('services.ally.discord')
+
+    if (!_.hasAll(config, ['clientId', 'clientSecret', 'redirectUri'])) {
+      throw CE.OAuthException.missingConfig('discord')
+    }
+
+    super(config.clientId, config.clientSecret, config.headers)
+
+    /**
+     * Oauth specific values to be used when creating the redirect
+     * url or fetching user profile.
+     */
+    this._scope = this._getInitialScopes(config.scope)
+    this._redirectUri = config.redirectUri
+    this._redirectUriOptions = _.merge({response_type: 'code'}, config.options)
+  }
+
+  /**
+   * Injections to be made by the IoC container
+   *
+   * @return {Array}
+   */
+  static get inject () {
+    return ['Adonis/Src/Config']
+  }
+
+  /**
+   * Scope seperator for seperating multiple
+   * scopes.
+   *
+   * @return {String}
+   */
+  get scopeSeperator () {
+    return ' '
+  }
+
+  /**
+   * Base url to be used for constructing
+   * discord oauth urls.
+   *
+   * @return {String}
+   */
+  get baseUrl () {
+    return 'https://discordapp.com/api/oauth2'
+  }
+
+  /**
+   * Relative url to be used for redirecting
+   * user.
+   *
+   * @return {String} [description]
+   */
+  get authorizeUrl () {
+    return 'authorize'
+  }
+
+  /**
+   * Relative url to be used for exchanging
+   * access token.
+   *
+   * @return {String}
+   */
+  get accessTokenUrl () {
+    return 'token'
+  }
+
+  /**
+   * Returns initial scopes to be used right from the
+   * config file. Otherwise it will fallback to the
+   * commonly used scopes
+   *
+   * @param   {Array} scopes
+   *
+   * @return  {Array}
+   *
+   * @private
+   */
+  _getInitialScopes (scopes) {
+    return _.size(scopes) ? scopes : ['identify', 'email']
+  }
+
+  /**
+   * Returns the user profile as an object using the
+   * access token
+   *
+   * @param   {String} accessToken
+   *
+   * @return  {Object}
+   *
+   * @private
+   */
+  * _getUserProfile (accessToken) {
+    const profileUrl = 'https://discordapp.com/api/users/@me'
+    const response = yield got(profileUrl, {
+      headers: {
+        'Accept': 'application/json',
+        'Authorization': `Bearer ${accessToken}`
+      },
+      json: true
+    })
+    return response.body
+  }
+
+  /**
+   * Returns the redirect url for a given provider
+   *
+   * @param  {Array} scope
+   *
+   * @return {String}
+   */
+  * getRedirectUrl (scope) {
+    scope = _.size(scope) ? scope : this._scope
+    return this.getUrl(this._redirectUri, scope, this._redirectUriOptions)
+  }
+
+  /**
+   * Parses the redirect errors returned by discord
+   * and returns the error message.
+   *
+   * @param  {Object} queryParams
+   *
+   * @return {String}
+   */
+  parseRedirectError (queryParams) {
+    return queryParams.error || 'Oauth failed during redirect'
+  }
+
+  /**
+   * Returns the user profile with it's access token, refresh token
+   * and token expiry
+   *
+   * @param {Object} queryParams
+   *
+   * @return {Object}
+   */
+  * getUser (queryParams) {
+    const code = queryParams.code
+
+    /**
+     * Throw an exception when query string does not have
+     * code.
+     */
+    if (!code) {
+      const errorMessage = this.parseRedirectError(queryParams)
+      throw CE.OAuthException.tokenExchangeException(errorMessage, null, errorMessage)
+    }
+
+    const accessTokenResponse = yield this.getAccessToken(code, this._redirectUri, {
+      grant_type: 'authorization_code'
+    })
+    const userProfile = yield this._getUserProfile(accessTokenResponse.accessToken)
+    const user = new AllyUser()
+    user
+      .setOriginal(userProfile)
+      .setFields(
+        userProfile.id,
+        userProfile.username,
+        userProfile.email,
+        userProfile.username,
+        `data:image/jpeg;base64,${userProfile.avatar}`
+      )
+      .setToken(
+        accessTokenResponse.accessToken,
+        accessTokenResponse.refreshToken,
+        null,
+        Number(_.get(accessTokenResponse, 'result.expires_in'))
+      )
+    return user
+  }
+}
+
+module.exports = Discord

--- a/src/Drivers/index.js
+++ b/src/Drivers/index.js
@@ -14,5 +14,6 @@ module.exports = {
   github: require('./Github'),
   google: require('./Google'),
   linkedin: require('./LinkedIn'),
-  twitter: require('./Twitter')
+  twitter: require('./Twitter'),
+  discord: require('./Discord')
 }


### PR DESCRIPTION
Hi,

Here is the Discord OAuth2 provider ([https://discordapp.com/developers/docs/topics/oauth2](https://discordapp.com/developers/docs/topics/oauth2))

