### PR TITLE
fix(twitter): fetch id_str and https picture

### DIFF
--- a/src/Drivers/Twitter.js
+++ b/src/Drivers/Twitter.js
@@ -115,11 +115,11 @@ class Twitter extends OAuthScheme {
     user
       .setOriginal(userProfile)
       .setFields(
-        userProfile.id,
+        userProfile.id_str,
         userProfile.screen_name,
         userProfile.email,
         userProfile.name,
-        userProfile.profile_image_url.replace('_normal.jpg', '.jpg')
+        userProfile.profile_image_url_https.replace(/_normal(\.\w+)$/, '$1')
       )
       .setToken(accessTokenResponse.accessToken, null, accessTokenResponse.tokenSecret, null)
 


### PR DESCRIPTION
## Proposed changes

Fixes few bugs: bad ID and HTTP profile pictures URIs were fetched.
- Replaced id to id_str because it wasn't used correctly as an integer.
- Fetched profile_image_url_https
- Improved "_normal" replacement (sometimes you can have .png or .gif profile pictures).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-ally/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)