### PR TITLE
Update facebook graph api version

### DIFF
--- a/src/Drivers/Facebook.js
+++ b/src/Drivers/Facebook.js
@@ -91,7 +91,7 @@ class Facebook extends OAuth2Scheme {
    * @return {String}
    */
   get baseUrl () {
-    return 'https://graph.facebook.com/v2.1'
+    return 'https://graph.facebook.com/v4.0'
   }
 
   /**

--- a/test/drivers.spec.js
+++ b/test/drivers.spec.js
@@ -185,7 +185,7 @@ test.group('Oauth Drivers | Facebook', function () {
     const facebook = new Facebook(config)
     const redirectUrl = qs.escape(config.get().redirectUri)
     const scope = qs.escape(['email'].join(','))
-    const providerUrl = `https://graph.facebook.com/v2.1/oauth/authorize?redirect_uri=${redirectUrl}&scope=${scope}&response_type=code&client_id=${config.get().clientId}`
+    const providerUrl = `https://graph.facebook.com/v4.0/oauth/authorize?redirect_uri=${redirectUrl}&scope=${scope}&response_type=code&client_id=${config.get().clientId}`
     const redirectToUrl = await facebook.getRedirectUrl()
     assert.equal(redirectToUrl, providerUrl)
   })
@@ -204,7 +204,7 @@ test.group('Oauth Drivers | Facebook', function () {
     const facebook = new Facebook(customConfig)
     const redirectUrl = qs.escape(customConfig.get().redirectUri)
     const scope = qs.escape(['email', 'name'].join(','))
-    const providerUrl = `https://graph.facebook.com/v2.1/oauth/authorize?redirect_uri=${redirectUrl}&scope=${scope}&response_type=code&client_id=${customConfig.get().clientId}`
+    const providerUrl = `https://graph.facebook.com/v4.0/oauth/authorize?redirect_uri=${redirectUrl}&scope=${scope}&response_type=code&client_id=${customConfig.get().clientId}`
     const redirectToUrl = await facebook.getRedirectUrl()
     assert.equal(redirectToUrl, providerUrl)
   })
@@ -213,7 +213,7 @@ test.group('Oauth Drivers | Facebook', function () {
     const facebook = new Facebook(config)
     const redirectUrl = qs.escape(config.get().redirectUri)
     const scope = qs.escape(['foo'].join(','))
-    const providerUrl = `https://graph.facebook.com/v2.1/oauth/authorize?redirect_uri=${redirectUrl}&scope=${scope}&response_type=code&client_id=${config.get().clientId}`
+    const providerUrl = `https://graph.facebook.com/v4.0/oauth/authorize?redirect_uri=${redirectUrl}&scope=${scope}&response_type=code&client_id=${config.get().clientId}`
 
     facebook.scope = ['foo']
     const redirectToUrl = await facebook.getRedirectUrl()
@@ -254,7 +254,7 @@ test.group('Oauth Drivers | Facebook', function () {
     const scope = qs.escape(['email'].join(','))
     const state = '1234'
 
-    const providerUrl = `https://graph.facebook.com/v2.1/oauth/authorize?redirect_uri=${redirectUrl}&scope=${scope}&response_type=code&state=${state}&client_id=${config.get().clientId}`
+    const providerUrl = `https://graph.facebook.com/v4.0/oauth/authorize?redirect_uri=${redirectUrl}&scope=${scope}&response_type=code&state=${state}&client_id=${config.get().clientId}`
 
     const redirectToUrl = await facebook.getRedirectUrl(state)
     assert.equal(redirectToUrl, providerUrl)


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Changed Graph API v2.10 endpoint which will reach the end of its 2-year lifetime on 05 November, 2019.

## Types of changes

Migrated to v4.0 right away as it will be supported till August 3, 2021. Core data is still available.

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-ally/blob/develop/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
